### PR TITLE
Replace for loop with logical indexing

### DIFF
--- a/ampdLib.py
+++ b/ampdLib.py
@@ -52,7 +52,7 @@ def ampd(sigInput):
 	
 	# Find minima				
 	G = np.sum(LSM, 1)
-	l = np.where(G == G.min())[0]
+	l = np.where(G == G.min())[0][0]
 	
 	LSM = LSM[0:l, :]
 	

--- a/ampdLib.py
+++ b/ampdLib.py
@@ -45,10 +45,12 @@ def ampd(sigInput):
 	
 	# Local minima extraction
 	for k in np.arange(1, L):
-		for i in range(k+1, N-k):
-			if((sigInput[i-1, 0] > sigInput[i-k-1, 0]) 
-			& (sigInput[i-1, 0] > sigInput[i+k-1, 0])):
-				LSM[k-1, i-1] = 0
+		locMax = np.zeros(N, dtype=bool)
+		mask = (sigInput[k:N - k - 1] > sigInput[0: N - 2 * k - 1]) & (sigInput[k:N - k - 1] > sigInput[2 * k: N - 1])
+		mask = mask.flatten()
+
+		locMax[k:N-k-1] = mask
+		LSM[k - 1, locMax] = 0
 	
 	# Find minima				
 	G = np.sum(LSM, 1)


### PR DESCRIPTION
The inner for loop of calculating the LSM can be replaced by logical indexing which leads to a decrease in computation time:

for loop:
```
%timeit ampd_old(np.sin(np.linspace(-np.pi, 10*np.pi, 201)))
15.6 ms ± 23 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

logical indexing:
```
%timeit ampd(np.sin(np.linspace(-np.pi, 10*np.pi, 201)))
2.55 ms ± 26.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
